### PR TITLE
Devfw

### DIFF
--- a/src/app/modules/msp-register/components/msp-register-organization/msp-register-organization.component.ts
+++ b/src/app/modules/msp-register/components/msp-register-organization/msp-register-organization.component.ts
@@ -38,7 +38,16 @@ export class MspRegisterOrganizationComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.fg.valueChanges.subscribe(obs => console.log(this.fg));
+    this.fg.valueChanges.subscribe(
+      obs => {
+
+            console.log(this.fg);
+
+            // converts postalcode in upper case
+            const postalCode = this.fg.get('postalCode');
+            postalCode.setValue(postalCode.value.toUpperCase(), {emitEvent: false});
+      }
+      );
   }
 
   continue() {

--- a/src/app/modules/msp-register/models/msp-register-organization.ts
+++ b/src/app/modules/msp-register/models/msp-register-organization.ts
@@ -17,7 +17,7 @@ export class MspRegisterOrganization extends GenerateForm<IMspOrganization>
   get validators() {
     return {
       name: [required, Validators.maxLength(100)],
-      address: [required, minLength(), maxLength(100)],
+      address: [required, minLength(), maxLength(200)],
       city: [required, minLength(), maxLength(25)],
       province: [required, minLength(2), maxLength(3)],
       postalCode: [required, maxLength(6), postalCodeValidator()],


### PR DESCRIPTION
1. Address length decreased 1024 to 200 in new schema
2. postalCode in new schema is 
`"postal_code": {
          "type": "string",
          "pattern": "^ABCEGHJ-NPRSTV-Z][0-9][ABCEGHJ-NPRSTV-Z][0-9][ABCEGHJ-NPRSTV-Z][0-9]$"
        },`
i think existing is correct **^[ABCEGHJ-NPRSTV-Z][0-9][ABCEGHJ-NPRSTV-Z][0-9][ABCEGHJ-NPRSTV-Z][0-9]**  , a reference [postal-codes-Canada-wiki](https://en.wikipedia.org/wiki/Postal_codes_in_Canada)

3. ux improvement - As user types this converts the text to upper case

